### PR TITLE
fix(ci): Cleanup space as first step to avoid "no space left on device"

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -37,7 +37,7 @@ jobs:
       IMAGE_NAME: "chatterino/${{ matrix.image-name }}"
 
     steps:
-      - name: Free Disc Space
+      - name: Free Disk Space
         uses: jlumbroso/free-disk-space@main
         with:
           # this might remove tools that are actually needed,


### PR DESCRIPTION
Hopefully it works. In my Test PR it seems like it because I'm in the "Test docker image" step and don't want to wait for it to finish before creating this PR.
This is the action I've used: https://github.com/marketplace/actions/free-disk-space-ubuntu