### PR TITLE
Dynamically get repository owner for docker image in workflow

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -34,7 +34,7 @@ jobs:
     env:
       C2_PLUGINS: "ON"
       C2_BUILD_WITH_QT6: "ON"
-      IMAGE_NAME: "chatterino/${{ matrix.image-name }}"
+      IMAGE_NAME: "${{ github.repository_owner }}/${{ matrix.image-name }}"
 
     steps:
       - name: Free Disk Space

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -116,9 +116,11 @@ jobs:
           # If the image-name is chatterino2-xd, the Dockerfile it will look for is Dockerfile_chatterino2-xd
           - image-name: chatterino2-test-httpbox
     env:
-      IMAGE_NAME: "chatterino/${{ matrix.image-name }}"
+      IMAGE_NAME: "${{ github.repository_owner }}/${{ matrix.image-name }}"
 
     steps:
+      - name: Lowercase Repo Owner in IMAGE_NAME env var
+        run: echo "IMAGE_NAME=${IMAGE_NAME,,}" >> "${GITHUB_ENV}"
       - uses: actions/checkout@v6
         with:
           path: "chatterino-docker"

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -37,6 +37,8 @@ jobs:
       IMAGE_NAME: "${{ github.repository_owner }}/${{ matrix.image-name }}"
 
     steps:
+      - name: Lowercase Repo Owner in IMAGE_NAME env var
+        run: echo "IMAGE_NAME=${IMAGE_NAME,,}" >> "${GITHUB_ENV}"
       - name: Free Disk Space
         uses: jlumbroso/free-disk-space@main
         with:


### PR DESCRIPTION
My thinking was so you don't have to change the workflow when having a fork of this repository. I'm not sure if we want that, but I thought that this PR could be a good place to suggest it. Since I only use my fork for testing and PRing upstream, I don't mind either way.