### PR TITLE
feat: Bump 22.04 GCC from 11 to 12

### DIFF
--- a/Dockerfile_chatterino2-build-ubuntu-22.04
+++ b/Dockerfile_chatterino2-build-ubuntu-22.04
@@ -224,6 +224,8 @@ ENV QT_QPA_PLATFORM=minimal
 ENV PATH="/usr/local-cmake/bin:${PATH}"
 ENV Qt6_DIR="/usr/local-qt"
 ENV Boost_DIR="/usr/local-boost"
+ENV CC=gcc-12
+ENV CXX=g++-12
 
 RUN <<EOF
 set -e
@@ -232,6 +234,7 @@ apt-get update
 
 apt-get install -y --no-install-recommends \
     build-essential \
+    g++-12 \
     ca-certificates \
     libssl-dev \
     locales \


### PR DESCRIPTION
The main reason is improved C++ 23 support in both the compiler itself and libstdc++. See https://cppstat.dev/?tags=cpp,c,gcc%3D12 for a list of new features.