### PR TITLE
Add 26.04 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@ Now you'll have an executable you can use or package in `/home/user/chatterino2/
 ## Ubuntu 24.04
 
 See the 22.04 instructions above and replace 22.04 with 24.04
+
+## Ubuntu 26.04
+
+See the 22.04 instructions above and replace 22.04 with 26.04


### PR DESCRIPTION
Just noticed that I didn't update the README when I added the Dockerfile for Ubuntu 26.04